### PR TITLE
Add concept api service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "postcss-normalize": "^10.0.1",
         "postcss-preset-env": "^7.0.1",
         "prompts": "^2.4.2",
+        "queue-typescript": "^1.0.1",
         "react": "^18.2.0",
         "react-app-polyfill": "^3.0.0",
         "react-dev-utils": "^12.0.1",
@@ -11707,6 +11708,11 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/linked-list-typescript": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/linked-list-typescript/-/linked-list-typescript-1.0.15.tgz",
+      "integrity": "sha512-RIyUu9lnJIyIaMe63O7/aFv/T2v3KsMFuXMBbUQCHX+cgtGro86ETDj5ed0a8gQL2+DFjzYYsgVG4I36/cUwgw=="
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -14074,6 +14080,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/queue-typescript": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-typescript/-/queue-typescript-1.0.1.tgz",
+      "integrity": "sha512-tkK08uPfmpPl0cX1WRSU3EoNb/T5zSoZPGkkpfGX4E8QayWvEmLS2cI3pFngNPkNTCU5pCDQ1IwlzN0L5gdFPg==",
+      "dependencies": {
+        "linked-list-typescript": "^1.0.11"
+      }
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -25518,6 +25532,11 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "linked-list-typescript": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/linked-list-typescript/-/linked-list-typescript-1.0.15.tgz",
+      "integrity": "sha512-RIyUu9lnJIyIaMe63O7/aFv/T2v3KsMFuXMBbUQCHX+cgtGro86ETDj5ed0a8gQL2+DFjzYYsgVG4I36/cUwgw=="
+    },
     "loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -27034,6 +27053,14 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "queue-typescript": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-typescript/-/queue-typescript-1.0.1.tgz",
+      "integrity": "sha512-tkK08uPfmpPl0cX1WRSU3EoNb/T5zSoZPGkkpfGX4E8QayWvEmLS2cI3pFngNPkNTCU5pCDQ1IwlzN0L5gdFPg==",
+      "requires": {
+        "linked-list-typescript": "^1.0.11"
+      }
     },
     "quick-lru": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "postcss-normalize": "^10.0.1",
     "postcss-preset-env": "^7.0.1",
     "prompts": "^2.4.2",
+    "queue-typescript": "^1.0.1",
     "react": "^18.2.0",
     "react-app-polyfill": "^3.0.0",
     "react-dev-utils": "^12.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,34 @@
 import React, { type ReactElement } from "react";
 import "./App.css";
 import "reflect-metadata";
+import { type IConcepts, TYPES, container } from "./services";
 import { SearchBar } from "./components/search/search-bar";
 
 function App(): ReactElement {
+  const writeResults = (results: string): void => {
+    const resultsDiv = document.getElementById("results");
+    if (resultsDiv !== null) {
+      resultsDiv.innerText = results;
+    }
+  };
+
+  const onSearchSubmit = (term: string): void => {
+    const concepts = container.resolve<IConcepts>(TYPES.IConcept);
+    concepts.getConcepts(term)
+      .then(jsonString => { writeResults(jsonString); })
+      .catch((error: Error) => { writeResults(error.message); });
+  };
+
   return (
     <div className="App">
       <div className="navy georgia ma0 grow">
         <h2 className="f2">Find English Language Parent Concepts</h2>
       </div>
-      <SearchBar onSubmit={searchTerm => { console.log(searchTerm); }}/>
+      <SearchBar onSubmit={onSearchSubmit}/>
       <div
-        className="tl navy georgia ma5 pa3 grow ba b--dashed"
+        className="tl navy georgia ma5 pa3 ba b--dashed"
         id="results"
+        style={{ whiteSpace: "pre-wrap" }}
       />
     </div>
   );

--- a/src/services/concepts/IConcepts.ts
+++ b/src/services/concepts/IConcepts.ts
@@ -1,0 +1,6 @@
+
+export interface ConceptOutputType { [key: string]: ConceptOutputType }
+
+export interface IConcepts {
+  getConcepts: (term: string) => Promise<string>
+}

--- a/src/services/concepts/concept-net-api.ts
+++ b/src/services/concepts/concept-net-api.ts
@@ -1,0 +1,77 @@
+import { injectable } from "tsyringe";
+import { Queue } from "queue-typescript";
+import { type IConcepts } from "./IConcepts";
+
+interface ConceptApiEdgeType { end: { label: string }}
+interface GraphType { [key: string]: GraphType }
+
+@injectable()
+export class ConceptNetApi implements IConcepts {
+  async getConcepts(term: string): Promise<string> {
+    const conceptsMap = await this.fetchConceptsRecursively(term, 100);
+    const hierarchicalJson = await this.generateHierarchicalJson(conceptsMap, term);
+
+    return hierarchicalJson;
+  }
+
+  private escapeTerm(term: string): string {
+    return term.split(" ").join("_");
+  }
+
+  private async fetchConceptsRecursively(term: string, limit: number): Promise<Map<string, string[]>> {
+    let currentLimit = limit;
+    const conceptsMap = new Map<string, string[]>();
+    const q = new Queue<{ level: number, term: string }>();
+    q.enqueue({ level: 0, term });
+
+    while (q.length > 0) {
+      const { level, term: newTerm } = q.dequeue();
+      console.log(`level: '${level}', term: '${newTerm}'`);
+      if (!conceptsMap.has(newTerm)) {
+        const concepts = await this.fetchConcepts(newTerm, currentLimit);
+        const filteredConcepts = concepts.filter(concept => concept !== newTerm);
+        conceptsMap.set(newTerm, filteredConcepts);
+
+        filteredConcepts.forEach(concept => { q.enqueue({ level: level + 1, term: concept }); });
+        currentLimit -= filteredConcepts.length;
+      }
+    }
+
+    return conceptsMap;
+  }
+
+  private async generateHierarchicalJson(conceptsMap: Map<string, string[]>, term: string): Promise<string> {
+    const nodeList: GraphType = {};
+
+    conceptsMap.forEach((values, key) => {
+      nodeList[key] = {};
+    });
+
+    conceptsMap.forEach((values, key) => {
+      values.forEach(child => {
+        nodeList[key][child] = nodeList[child];
+      });
+    });
+
+    return JSON.stringify(nodeList[term], null, 4);
+  }
+
+  private async fetchConcepts(term: string, limit: number): Promise<string[]> {
+    // prepare url to fetch search results
+    const baseAddress = "https://api.conceptnet.io";
+    const preparedQuery = `/c/en/${this.escapeTerm(term)}`;
+    const encodedQuery = encodeURIComponent(preparedQuery);
+    const encodedLimit = encodeURIComponent(limit);
+    const preparedUrl = `${baseAddress}/query?start=${encodedQuery}&rel=/r/IsA&limit=${encodedLimit}`;
+
+    const response = await fetch(preparedUrl);
+    if (!response.ok) {
+      throw new Error(response.statusText);
+    }
+
+    const data = await response.json();
+    const edges: ConceptApiEdgeType[] = data.edges;
+
+    return edges.map(edge => edge.end.label);
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,16 @@
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { type IConcepts } from "./concepts/IConcepts";
+import { ConceptNetApi } from "./concepts/concept-net-api";
+
+export const TYPES = {
+  IConcept: Symbol.for("IConcept")
+};
+
+export type { IConcepts };
+
+container.register(TYPES.IConcept, {
+  useClass: ConceptNetApi
+});
+
+export { container };


### PR DESCRIPTION
Add concept api to  retrieve "is a" relationships of the search term.

- We first create a map of the concepts. This ensures that we don't re-call the API for concepts we have covered. 
- Then we convert this concept map into the required hierarchical JSON structure.
- We also take steps to remove circular concept mappings